### PR TITLE
fix: Fix BLE disconnection callback error with improved dependency injection

### DIFF
--- a/src/meshcore/ble_cx.py
+++ b/src/meshcore/ble_cx.py
@@ -20,13 +20,15 @@ UART_TX_CHAR_UUID = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
 
 
 class BLEConnection:
-    def __init__(self, address=None, device=None, client=None):
+    def __init__(self, address=None, device=None, client=None, disconnect_callback=None):
         """
         Constructor: specify address or an existing BleakClient.
 
         Args:
             address (str, optional): The Bluetooth address of the device.
+            device (BLEDevice, optional): A BLEDevice instance.
             client (BleakClient, optional): An existing BleakClient instance.
+            disconnect_callback (callable, optional): Callback function to handle disconnections.
         """
         self.address = address
         self._user_provided_address = address
@@ -35,7 +37,8 @@ class BLEConnection:
         self.device = device
         self._user_provided_device = device
         self.rx_char = None
-        self._disconnect_callback = None
+        self._disconnect_callback = disconnect_callback
+        self.reader = None  # Initialize reader to None
 
     async def connect(self):
         """
@@ -122,6 +125,11 @@ class BLEConnection:
     def set_disconnect_callback(self, callback):
         """Set callback to handle disconnections."""
         self._disconnect_callback = callback
+        
+    # Maintain compatibility with both naming conventions
+    def set_disconnected_callback(self, callback):
+        """Alias for set_disconnect_callback to maintain compatibility."""
+        self.set_disconnect_callback(callback)
 
     def set_reader(self, reader):
         self.reader = reader

--- a/src/meshcore/connection_manager.py
+++ b/src/meshcore/connection_manager.py
@@ -35,7 +35,7 @@ class ConnectionManager:
 
     def __init__(
         self,
-        connection: ConnectionProtocol,
+        connection: Optional[ConnectionProtocol] = None,
         event_dispatcher=None,
         auto_reconnect: bool = False,
         max_reconnect_attempts: int = 3,
@@ -49,6 +49,10 @@ class ConnectionManager:
         self._is_connected = False
         self._reconnect_task = None
         self._disconnect_callback: Optional[Callable] = None
+        
+    def _set_connection(self, connection: ConnectionProtocol):
+        """Set the connection instance. Used internally for dependency injection."""
+        self.connection = connection
 
     def set_disconnect_callback(self, callback: Callable):
         """Set a callback to be called when disconnection is detected."""


### PR DESCRIPTION
Fixes an issue where BLE connections would fail with "'BleakClient' object has no attribute 'set_disconnected_callback'" error.

## Changes

- Implemented construction-time dependency injection for BLE connections
- Added `disconnect_callback` parameter to `BLEConnection.__init__`
- Created a `_set_connection()` method in ConnectionManager for delayed initialization
- Properly initialized reader attribute in BLEConnection
- Added proper reader setup in MeshCore.create_ble()
- Maintained backward compatibility with existing callback methods