### PR TITLE
Correctly use client in BLEConnection

### DIFF
--- a/src/meshcore/ble_cx.py
+++ b/src/meshcore/ble_cx.py
@@ -52,7 +52,7 @@ class BLEConnection:
         if self.client:
             logger.debug("Using pre-configured BleakClient.")
             assert isinstance(self.client, BleakClient)
-            if client.is_connected :
+            if self.client.is_connected :
                 logger.error("Client is already connected !!! weird")
                 self.address = self.client.address
                 return self.address


### PR DESCRIPTION
fix error while testing meshcore-cli on mac.

Not tested on any other configuration, but doesn't look like it would cause problems.