### PR TITLE
Add the pubkey prefix as a filterable attribute in the reader

### DIFF
--- a/src/meshcore/reader.py
+++ b/src/meshcore/reader.py
@@ -481,6 +481,7 @@ class MessageReader:
 
             attributes = {
                 "raw": buf.hex(),
+                "pubkey_prefix": res["pubkey_pre"],
             }
 
             await self.dispatcher.dispatch(


### PR DESCRIPTION
Adds the ability to filter on pubkey prefix in a telemetry response.
