### PR TITLE
Fix ADVERT_PATH parsing of embedded zero bytes

### DIFF
--- a/src/meshcore/reader.py
+++ b/src/meshcore/reader.py
@@ -149,7 +149,8 @@ class MessageReader:
                 else:
                     r["path_hash_mode"] = plen >> 6 # 2 upper bytes
                     r["path_len"] = plen & 0x3F
-                r["path"] = dbuf.read().replace(b"\0", b"").hex()
+                path_byte_count = r["path_len"] * (r["path_hash_mode"] + 1)
+                r["path"] = dbuf.read(path_byte_count).hex()
 
                 await self.dispatcher.dispatch(Event(EventType.ADVERT_PATH, r))
 

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -278,3 +278,28 @@ async def test_parse_packet_payload_txt_type_decodes_high_bits():
     assert log_data["attempt"] == 1, (
         f"Expected attempt=1, got {log_data['attempt']}"
     )
+
+
+@pytest.mark.asyncio
+async def test_advert_path_preserves_embedded_zero_bytes():
+    """ADVERT_PATH must preserve valid 0x00 bytes inside path hashes."""
+    dispatcher = _CapturingDispatcher()
+    reader = MessageReader(dispatcher)
+
+    # ADVERT_PATH (0x0e), 2 hops, 3-byte hashes.
+    # path_len byte: hash mode 2 (3 bytes) + 2 hops = 0x82.
+    # The first hash deliberately contains an embedded 0x00 byte.
+    packet = bytearray.fromhex("0e8212003456789a")
+
+    await reader.handle_rx(packet)
+
+    advert_path_events = [
+        e for e in dispatcher.events if e.type == EventType.ADVERT_PATH
+    ]
+
+    assert len(advert_path_events) == 1
+
+    payload = advert_path_events[0].payload
+    assert payload["path_hash_mode"] == 2
+    assert payload["path_len"] == 2
+    assert payload["path"] == "12003456789a"


### PR DESCRIPTION
Problem

The ADVERT_PATH parser currently removes all 0x00 bytes from the returned path using:

r["path"] = dbuf.read().replace(b"\0", b"").hex()

However, 0x00 is a valid byte inside a MeshCore path hash. Removing these bytes can corrupt the path and can also change the boundaries between individual hop hashes.

For example, a valid 3-byte hash:

12 00 34

would incorrectly become:

12 34

Fix

Instead of removing zero bytes, calculate the exact number of path bytes from the path length and hash mode:

path_byte_count = r["path_len"] * (r["path_hash_mode"] + 1)
r["path"] = dbuf.read(path_byte_count).hex()

This preserves all valid path bytes, including 0x00, while reading only the number of bytes actually belonging to the path.

This is also consistent with the existing contact-path parsing, which calculates the number of used path bytes rather than stripping zero bytes.

Impact

Without this fix, get_advert_path() can return a corrupted path whenever any hop hash contains a 0x00 byte.

The problem can occur with 1-byte, 2-byte, and 3-byte path hashes.
