### PR TITLE
Fix serial fd leak in SerialConnection.connect() on timeout

### DIFF
--- a/src/meshcore/serial_cx.py
+++ b/src/meshcore/serial_cx.py
@@ -71,14 +71,24 @@ class SerialConnection:
         self._connected_event.clear()
 
         loop = asyncio.get_running_loop()
-        await serial_asyncio.create_serial_connection(
+        transport, _ = await serial_asyncio.create_serial_connection(
             loop,
             lambda: self.MCSerialClientProtocol(self),
             self.port,
             baudrate=self.baudrate,
         )
 
-        await asyncio.wait_for(self._connected_event.wait(), timeout=timeout)
+        try:
+            await asyncio.wait_for(self._connected_event.wait(), timeout=timeout)
+        except Exception:
+            # create_serial_connection() already opened the port's fds;
+            # connection_made() never fired (or didn't in time) to hand them
+            # to self.transport, so close directly on the local reference or
+            # they leak until the process runs out of fds (#95).
+            if self.transport is transport:
+                self.transport = None
+            transport.close()
+            raise
         logger.info("Serial Connection started")
         return self.port
 

--- a/tests/unit/test_serial_connection.py
+++ b/tests/unit/test_serial_connection.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -29,3 +30,28 @@ async def test_handle_rx_discards_leading_junk_before_frame_start():
     assert conn.header == b""
     assert conn.inframe == b""
     assert conn.frame_expected_size == 0
+
+
+@pytest.mark.asyncio
+async def test_connect_closes_transport_on_timeout():
+    """Regression for #95: if connection_made() never fires before the
+    connect() timeout, the fds create_serial_connection() already opened
+    must not leak -- connect() should close the transport before raising."""
+    conn = SerialConnection("/dev/null", 115200)
+
+    mock_transport = MagicMock()
+    mock_protocol = MagicMock()
+
+    async def fake_create_serial_connection(loop, protocol_factory, port, baudrate):
+        # Never call connection_made(), so _connected_event stays unset.
+        return mock_transport, mock_protocol
+
+    with patch(
+        "meshcore.serial_cx.serial_asyncio.create_serial_connection",
+        side_effect=fake_create_serial_connection,
+    ):
+        with pytest.raises(asyncio.TimeoutError):
+            await conn.connect(timeout=0.05)
+
+    mock_transport.close.assert_called_once()
+    assert conn.transport is None


### PR DESCRIPTION
Fixes #95

## Problem
SerialConnection.connect() leaked 3 file descriptors (the serial port fd
plus two internal pipe fds) every time a connection attempt timed out.
In a reconnect loop against an unresponsive device, this exhausts the
~1024 fd limit and starts failing with "Too many open files".

## Root cause
serial_asyncio.create_serial_connection() opens the fds immediately, but
the transport was only ever captured via self.transport, which is
assigned inside MCSerialClientProtocol.connection_made() — an async
callback. If asyncio.wait_for(self._connected_event.wait(), ...) timed
out before connection_made() ran, self.transport stayed None, so there
was no way to close the already-opened transport. It was simply
abandoned.

## Fix
connect() now captures transport directly from create_serial_connection()'s
own return value instead of relying on self.transport being set. If the
subsequent wait_for() raises for any reason (timeout or otherwise), the
transport is closed before re-raising. Added a narrow guard
(`if self.transport is transport: self.transport = None`) for the case
where connection_made() fires right at the timeout boundary, so closing
this attempt's transport never clobbers self.transport if it's already
pointing at a different, unrelated connection. The success path
(logging + return self.port) is unchanged.

## Testing
Added tests/unit/test_serial_connection.py::test_connect_closes_transport_on_timeout,
which patches create_serial_connection to return a transport whose
connection_made() never fires, and asserts transport.close() is called
before the TimeoutError propagates.

Full suite: 180 passed, 2 failed (test_send_cmd,
test_advert_path_preserves_embedded_zero_bytes) — both pre-existing on a
clean main checkout, unrelated to this change.