### PR TITLE
Stop configuring the root logger on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,15 @@ meshcore = await MeshCore.create_serial("/dev/ttyUSB0", debug=True)
 
 This logs detailed information about commands sent and events received.
 
+meshcore_py does not configure Python's root logger or call `logging.basicConfig()` itself - it only attaches a `NullHandler` so it stays silent by default. To see its logs, configure logging in your own application, e.g.:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("meshcore").setLevel(logging.DEBUG)
+```
+
 ## Common Examples
 
 ### Sending Messages to Contacts

--- a/src/meshcore/__init__.py
+++ b/src/meshcore/__init__.py
@@ -9,9 +9,11 @@ from .packets import BinaryReqType
 from .serial_cx import SerialConnection
 from .tcp_cx import TCPConnection
 
-# Setup default logger
-logging.basicConfig(level=logging.INFO)
+# Setup default logger. Libraries must not configure the root logger (that's
+# the embedding application's call) - a NullHandler just silences the "no
+# handlers found" warning when the app hasn't configured logging at all.
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 __all__ = [
     "BinaryReqType",

--- a/src/meshcore/meshcore.py
+++ b/src/meshcore/meshcore.py
@@ -46,13 +46,13 @@ class MeshCore:
         self.commands = CommandHandler(default_timeout=default_timeout)
         self.commands.set_contact_getter_by_prefix(self.get_contact_by_key_prefix)
 
-        # Set up logger
+        # Set up logger. Only override the level when the caller explicitly
+        # asked for debug/only_error behavior - otherwise leave whatever
+        # level the embedding app already configured alone.
         if debug:
             logger.setLevel(logging.DEBUG)
         elif only_error:
             logger.setLevel(logging.ERROR)
-        else:
-            logger.setLevel(logging.INFO)
 
         # Set up connections
         self.commands.set_connection(self.connection_manager)


### PR DESCRIPTION
Fixes #58

## Problem
Importing meshcore_py called `logging.basicConfig(level=logging.INFO)` at
module load time, which configures Python's *root* logger for any
application that imports the library — silently overriding that
application's own logging setup. Separately, `MeshCore.__init__` always
called `logger.setLevel(...)` even when neither `debug` nor `only_error`
was passed, forcing the level to `INFO` and overriding whatever the
embedding app had already configured.

## Fix
- `src/meshcore/__init__.py`: removed the `basicConfig()` call. The module
  logger now just gets a `NullHandler`, so the library stays silent by
  default without emitting "no handlers found" warnings, and never touches
  the root logger.
- `src/meshcore/meshcore.py`: `MeshCore.__init__` now only calls
  `logger.setLevel(...)` when the caller explicitly passes `debug=True` or
  `only_error=True`. The default case (neither flag set) leaves whatever
  level the embedding app configured alone, instead of forcing `INFO`.
- `README.md`: added a short note after the Debug Mode section showing the
  idiomatic pattern for consumers who want meshcore's logs:

    import logging
    logging.basicConfig(level=logging.INFO)
    logging.getLogger("meshcore").setLevel(logging.DEBUG)

Confirmed the `logger` name exported from `__init__.py`'s `__all__` isn't
referenced anywhere else in the package or examples, so removing
`basicConfig` doesn't change what that export points to for existing users
who import it directly.

## Testing
Checked tests/ for anything depending on the implicit `basicConfig` (grep
for `basicConfig`/`getLogger`/`caplog`) — the only hits are
`caplog.at_level(...)` calls in test_reader.py, which set their own level
independently and needed no changes.

Full suite: 179 passed, 2 failed (test_send_cmd,
test_advert_path_preserves_embedded_zero_bytes) — both pre-existing on a
clean main checkout, unrelated to this change.