### PR TITLE
Document set_path_hash_mode / get_path_hash_mode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,8 @@ All commands are async methods that return `Event` objects. Commands are organiz
 | `get_stats_packets()` | None | `STATS_PACKETS` | Get packet statistics (rx/tx totals, flood vs. direct, recv_errors when present) |
 | **Advanced Configuration** ||||
 | `set_multi_acks(multi_acks)` | `multi_acks: int` | `OK` | Set multi-acks mode (experimental ack repeats) |
+| `set_path_hash_mode(mode)` | `mode: int` | `OK` | Set the device's path hash mode: how many bytes of each hop's node ID are stored per hop in advertised/logged paths (bytes per hop = `mode + 1`, e.g. mode 0 = 1 byte/hop, mode 1 = 2 bytes/hop) |
+| `get_path_hash_mode()` | None | `int` | Get the device's current path hash mode |
 
 #### Contact Commands (`meshcore.commands.*`)
 


### PR DESCRIPTION
Fixes #84

## Problem
`set_path_hash_mode()` and `get_path_hash_mode()` already existed in
src/meshcore/commands/device.py, but neither was listed in README.md's
command reference table, so there was no way to discover them short of
reading the source. The issue reporter assumed the functionality itself
was missing.

## Fix
Added both to the Device Commands table under "Advanced Configuration",
next to the existing set_multi_acks entry. The description explains what
path hash mode actually controls — how many bytes of each hop's node ID
are stored per hop in advertised/logged paths (bytes per hop = mode + 1) —
based on the actual encoding logic in reader.py
(`path_hash_mode = plen >> 6`, `path_byte_count = path_len *
(path_hash_mode + 1)`) and commands/base.py's encode_reply_path, not just
a restated stub.

No code changes — docs only.

## Testing
Full suite: 179 passed, 2 failed (test_send_cmd,
test_advert_path_preserves_embedded_zero_bytes) — both pre-existing on a
clean main checkout, unrelated to this change.